### PR TITLE
Add CircleCI PyPI publish workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,11 +5,27 @@ executors:
     docker:
       - image: cimg/python:3.13
 
+commands:
+  checkout-public-repo:
+    steps:
+      - run:
+          name: Checkout code
+          command: |
+            set -eu
+            git init .
+            git remote add origin https://github.com/kylecaston/checkenv.git
+            if [ -n "${CIRCLE_TAG:-}" ]; then
+              git fetch --depth=1 origin "refs/tags/${CIRCLE_TAG}"
+            else
+              git fetch --depth=1 origin "refs/heads/${CIRCLE_BRANCH}"
+            fi
+            git checkout --detach FETCH_HEAD
+
 jobs:
   build-and-test:
     executor: python-313
     steps:
-      - checkout
+      - checkout-public-repo
       - run:
           name: Install dependencies
           command: |
@@ -28,7 +44,7 @@ jobs:
       TWINE_USERNAME: __token__
       TWINE_NON_INTERACTIVE: "1"
     steps:
-      - checkout
+      - checkout-public-repo
       - run:
           name: Install packaging tools
           command: python -m pip install --upgrade pip build twine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,32 +1,63 @@
 version: 2.1
 
-orbs:
-  python: circleci/python@0.2.1
-
 executors:
-  python-multiple:
+  python-313:
     docker:
-      - image: fkrull/multi-python
+      - image: cimg/python:3.13
 
 jobs:
   build-and-test:
-    executor: python-multiple
+    executor: python-313
     steps:
       - checkout
-      #- python/load-cache
       - run:
           name: Install dependencies
-          command: pip3 install -r requirements.txt
-      #- python/save-cache
+          command: |
+            python -m pip install --upgrade pip setuptools wheel
+            python -m pip install -r requirements.txt pytest-cov
       - run:
           name: Run tests and coverage
-          command: tox
+          command: python -m pytest --cov=checkenv --cov-report=term-missing -vv
       - run:
           name: Update coverage
-          command: COVERALLS_REPO_TOKEN=$COVERALLS_REPO_TOKEN coveralls
+          command: coveralls
+
+  publish-to-pypi:
+    executor: python-313
+    environment:
+      TWINE_USERNAME: __token__
+      TWINE_NON_INTERACTIVE: "1"
+    steps:
+      - checkout
+      - run:
+          name: Install packaging tools
+          command: python -m pip install --upgrade pip build twine
+      - run:
+          name: Build distributions
+          command: python -m build
+      - run:
+          name: Validate distributions
+          command: python -m twine check dist/*
+      - run:
+          name: Publish distributions to PyPI
+          command: python -m twine upload dist/*
+      - store_artifacts:
+          path: dist
 
 workflows:
   main:
     jobs:
       - build-and-test:
           context: checkenv
+          filters:
+            tags:
+              only: /.*/
+      - publish-to-pypi:
+          context: checkenv
+          requires:
+            - build-and-test
+          filters:
+            tags:
+              only: /^v[0-9]+(\.[0-9]+){2}.*$/
+            branches:
+              ignore: /.*/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Summary
- replace the stale CircleCI multi-python image with a current Python 3.13 image
- add a tag-only PyPI publish job that builds, validates, and uploads distributions with Twine
- add `pyproject.toml` build-system metadata for isolated package builds

## Validation
- `circleci config validate .circleci/config.yml`
- `python -m pytest --cov=checkenv --cov-report=term-missing -vv`
- `python -m build`
- `python -m twine check dist/*`

## Release note
The publish job only runs for `vX.Y.Z` tags and expects `TWINE_PASSWORD` to be configured in the existing CircleCI `checkenv` context before the first real release tag.