### PR TITLE
Bump filelock floor for Snyk

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dev = [
     "pytest>=9.0",
     "pytest-cov>=7.0",
     # Keep transitive dev dependencies above Snyk-reported vulnerable ranges.
-    "filelock>=3.20.1",
+    "filelock>=3.20.3",
     "requests>=2.32.4",
     "ruff>=0.8",
     "tox>=4.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ tox>=4.0
 twine>=6.0
 urllib3>=2.6.3
 zipp>=3.19.1
-filelock>=3.20.1 # not directly required, pinned by Snyk to avoid a vulnerability
+filelock>=3.20.3 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
## Summary
- Raise the dev dependency floor for filelock from 3.20.1 to 3.20.3 in both pyproject.toml and requirements.txt.
- Keep zipp unchanged because the current main branch already requires zipp>=3.19.1, matching Snyk's requested fix.

## Notes
- The Snyk screenshot appears to show the old master branch state, but this repo's remote currently exposes main as the only mainline branch.
- Local Snyk scan against the updated requirements.txt reports no vulnerable paths.

## Tests
- /private/tmp/checkenv-venv/bin/python -m pytest -vv
- env PATH=/private/tmp/checkenv-venv/bin:/Users/kylecaston/.nvm/versions/node/v20.19.6/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/Users/kylecaston/.codex/tmp/arg0/codex-arg0SIluIL:/opt/homebrew/opt/ruby/bin:/Users/kylecaston/.nvm/versions/node/v20.19.6/bin:/Applications/Codex.app/Contents/Resources snyk test --file=requirements.txt --package-manager=pip